### PR TITLE
Better mismatched expected / received actions display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "4"
 script:
-  - npm test
+  - npm run lint
+  - npm run coverage

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "scripts": {
     "compile": "babel --optional runtime -d lib/ src/",
     "prepublish": "npm run compile",
-    "test": "eslint src test && istanbul cover --report html _mocha -- test/**/*_test.js --opts mocha.opts"
+    "lint": "eslint src test",
+    "test": "mocha --compilers js:babel-core/register test/**/*_test.js",
+    "coverage": "istanbul cover --report html _mocha -- test/**/*_test.js --opts mocha.opts"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,7 @@ function createListenForActions(store, stateFunc, actionListFunc, blacklistedAct
           if (_.isEqual(actionListTypes, expectedActionTypes)) {
             resolve(stateFunc(store.getState()));
           } else if (actionListTypes.length > expectedActionTypes.length) {
-            reject(new Error("Received more actions than expected: actionListTypes: " +
-              JSON.stringify(actionListTypes) + ", expectedActionTypes: " + JSON.stringify(expectedActionTypes)));
+            reject(new Error(formatActionErrors(expectedActionTypes, actionListTypes)));
           }
         };
 
@@ -145,3 +144,32 @@ export default function configureTestStore(rootReducer, initialState, blackliste
   );
   return store;
 }
+
+const arrayDiff = (xs, ys) => xs.filter(x => ys.indexOf(x) < 0);
+
+const formatActions = xs => xs.map(x => `    ${x},`);
+
+const formatActionErrors = (expected, received) => {
+  let lines = [
+    "ReduxAsserts: didn't receive the expected actions\n"
+  ];
+
+  let unexpected = arrayDiff(received,expected);
+  if (unexpected.length !== 0) {
+    lines = lines.concat(
+      "Unexpected actions:",
+      "[", formatActions(unexpected), "]",
+      "\n"
+    );
+  }
+
+  let unreceived = arrayDiff(expected, received);
+  if (unreceived.length !== 0) {
+    lines = lines.concat(
+      "Expected, unreceived actions:",
+      "[", formatActions(unreceived), "]",
+      "\n"
+    );
+  }
+  return lines.join('\n');
+};

--- a/test/containers/Container.js
+++ b/test/containers/Container.js
@@ -20,8 +20,6 @@ class Container extends React.Component {
   }
 }
 
-export default Container;
-
 Container.propTypes = {
   dispatch: React.PropTypes.func.isRequired,
   checkbox: React.PropTypes.object.isRequired

--- a/test/containers/Container_test.js
+++ b/test/containers/Container_test.js
@@ -83,9 +83,15 @@ describe('listenForActions', () => {
     return listenForActions([CHECKBOX_UPDATED], () => {
       TestUtils.Simulate.change(checkbox);
     }).catch(e => {
-      assert.equal(e.message, 'Received more actions than expected: ' +
-        'actionListTypes: ["CHECKBOX_UPDATED","UPDATE_CHECKBOX"], ' +
-        'expectedActionTypes: ["CHECKBOX_UPDATED"]');
+      let expectation = `ReduxAsserts: didn't receive the expected actions
+
+Unexpected actions:
+[
+    UPDATE_CHECKBOX,
+]
+
+`;
+      assert.equal(e.message, expectation);
     });
   });
 
@@ -161,8 +167,14 @@ describe('listenForActions', () => {
       // callback is done to ensure any errors are thrown
       store.dispatch({ type: CHECKBOX_UPDATED, payload: true });
     }).catch(error => {
-      assert.equal('Received more actions than expected: actionListTypes: ["CHECKBOX_UPDATED","UPDATE_CHECKBOX"], ' +
-        'expectedActionTypes: ["UPDATE_CHECKBOX"]', error.message);
+      assert.equal(error.message, `ReduxAsserts: didn't receive the expected actions
+
+Unexpected actions:
+[
+    CHECKBOX_UPDATED,
+]
+
+`);
       done();
     });
   });

--- a/test/reducers/index_test.js
+++ b/test/reducers/index_test.js
@@ -57,8 +57,21 @@ describe('dispatchThen', () => {
 
   it("should reject the promise if the action types don't match", done => {
     dispatchThen(updateCheckbox(true), ['missing']).catch(e => {
-      assert.equal(e.message, 'Received more actions than expected: actionListTypes: ' +
-        '["CHECKBOX_UPDATED","UPDATE_CHECKBOX"], expectedActionTypes: ["missing"]');
+      assert.equal(e.message, `ReduxAsserts: didn't receive the expected actions
+
+Unexpected actions:
+[
+    CHECKBOX_UPDATED,
+    UPDATE_CHECKBOX,
+]
+
+
+Expected, unreceived actions:
+[
+    missing,
+]
+
+`);
       done();
     });
   });


### PR DESCRIPTION
This refactors how we display the action list when there's a mismatch between what is expected and what is received. Hopefully it's more readable!
